### PR TITLE
Return a dictionary of all drive results rather than just the first drive

### DIFF
--- a/demo/rules/smartctl_reallocated_sectors.py
+++ b/demo/rules/smartctl_reallocated_sectors.py
@@ -23,17 +23,21 @@ def smartctl_reallocated_sectors(smart_data):
     # the spec is based on the combination of a CommandSpec that uses a
     # matched pattern, and a PatternSpec.  Both of these reeturn multiple
     # drive information objects in a list, so we have to iterate across that:
+    drive_data = {}
     for drive in smart_data:
         if 'Reallocated_Sector_Ct' not in drive.attributes:
-            return
+            continue
 
         realloc_sector_ct = drive.attributes['Reallocated_Sector_Ct']['raw_value']
         if not realloc_sector_ct.isdigit():
             # We don't know what to do if this isn't a number.
-            return
+            continue
         if int(realloc_sector_ct) > 0:
-            return make_response(
-                ERROR_KEY,
-                device=drive.device,
-                reallocated_sectors=int(realloc_sector_ct)
-            )
+            drive_data[drive.device] == int(realloc_sector_ct)
+
+    if drive_data:
+        return make_response(
+            ERROR_KEY,
+            message=MESSAGE,
+            drive_data=drive_data,
+        )

--- a/demo/rules/smartctl_reallocated_sectors.py
+++ b/demo/rules/smartctl_reallocated_sectors.py
@@ -8,6 +8,7 @@ from insights.core.plugins import make_response, rule
 from insights.parsers.smartctl import SMARTctl
 
 ERROR_KEY = 'SMARTCTL_REALLOCATED_SECTORS'
+MESSAGE = 'Drives reporting reallocated sectors - the drives may fail soon'
 
 
 @rule([SMARTctl])

--- a/demo/tests/test_smartctl_reallocated_sectors.py
+++ b/demo/tests/test_smartctl_reallocated_sectors.py
@@ -210,10 +210,22 @@ def integration_tests():
     yield data, []
 
     # Test that should fail
+    # One drive:
     data = InputData("Reallocated sectors")
     data.add('smartctl', BAD_TEST_CONTENT, path="sos_commands/ata/smartctl_-a_.dev.sda")
     expected = make_response(
         smartctl_reallocated_sectors.ERROR_KEY,
         drive_data={'/dev/sda': 144},
+    )
+    yield data, [expected]
+
+    # One drive good, two drives bad
+    data = InputData("Reallocated sectors")
+    data.add('smartctl', GOOD_TEST_CONTENT, path="sos_commands/ata/smartctl_-a_.dev.sdd")
+    data.add('smartctl', BAD_TEST_CONTENT, path="sos_commands/ata/smartctl_-a_.dev.sda")
+    data.add('smartctl', BAD_TEST_CONTENT, path="sos_commands/ata/smartctl_-a_.dev.sdb")
+    expected = make_response(
+        smartctl_reallocated_sectors.ERROR_KEY,
+        drive_data={'/dev/sda': 144, '/dev/sdb': 144},
     )
     yield data, [expected]

--- a/demo/tests/test_smartctl_reallocated_sectors.py
+++ b/demo/tests/test_smartctl_reallocated_sectors.py
@@ -214,7 +214,6 @@ def integration_tests():
     data.add('smartctl', BAD_TEST_CONTENT, path="sos_commands/ata/smartctl_-a_.dev.sda")
     expected = make_response(
         smartctl_reallocated_sectors.ERROR_KEY,
-        device='/dev/sda',
-        reallocated_sectors=144
+        drive_data={'/dev/sda': 144},
     )
     yield data, [expected]


### PR DESCRIPTION
The loop logic returned on first non-match or match, so now we compile the drive results into a dictionary and check if that's got any data in it before returning a response.