### PR TITLE
Simplify reading from the RsyslogConf parser

### DIFF
--- a/demo/rules/rsyslog_dropping_messages.py
+++ b/demo/rules/rsyslog_dropping_messages.py
@@ -82,23 +82,9 @@ def find_rate_limiting_params(conf):
     'SystemLogRateLimitBurst' parameters.  They default to 5 seconds for the
     interval and 200 messages for the burst rate.
     """
-    if hasattr(conf, 'config_items') and hasattr(conf, 'config_val'):
-        # New style RsyslogConf object - get data directly
-        return (
-            int(conf.config_val('SystemLogRateLimitInterval', '5')),
-            int(conf.config_val('SystemLogRateLimitBurst', '200'))
-        )
-
-    # Old style RsyslogConf object - search through the lines
-    conf_re = re.compile(r'\$(?P<param>SystemLogRateLimit(?:Interval|Burst))\s+(?P<value>\d+)')
-    config_vals = {}
-    for line in conf.data:
-        match = conf_re.search(line)
-        if match:
-            config_vals[match.group('param')] = match.group('value')
     return (
-        int(config_vals.get('SystemLogRateLimitInterval', '5')),
-        int(config_vals.get('SystemLogRateLimitBurst', '200'))
+        int(conf.config_val('SystemLogRateLimitInterval', '5')),
+        int(conf.config_val('SystemLogRateLimitBurst', '200'))
     )
 
 

--- a/demo/rules/rsyslog_dropping_messages.py
+++ b/demo/rules/rsyslog_dropping_messages.py
@@ -75,7 +75,7 @@ def find_dropped_messages(log):
 Messages.scan('dropped_messages', find_dropped_messages)
 
 
-@condition([RsyslogConf])
+@condition(RsyslogConf)
 def find_rate_limiting_params(conf):
     """
     Try to determine the 'SystemLogRateLimitInterval' and
@@ -88,7 +88,7 @@ def find_rate_limiting_params(conf):
     )
 
 
-@rule([Messages, find_rate_limiting_params])
+@rule(Messages, find_rate_limiting_params)
 def rsyslog_dropping_messages(msgs, rate_params):
     """
     Use the file_dropped_messages scan to pick up if any


### PR DESCRIPTION
The RsyslogConf parser now always provides the `get_config` method, so we can remove the previous workaround in case it didn't.

Also simplifying the decorator arguments, as requirements don't need to be in a sub-list now.